### PR TITLE
feat: add a str_port member to configuration

### DIFF
--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -40,10 +40,12 @@ class Configuration
 		void			parse_arguments(int argc, char **argv);
 
 		uint16_t		getPort(void) const;
+		char			*getStrPort(void) const;
 
 	private:
 		bool		_parsed;
 		uint16_t	_port;
+		char		*_str_port;
 		std::string	_password;
 };
 

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -53,10 +53,16 @@ void	Configuration::parse_arguments(int argc, char **argv)
 		throw NotEnoughArguments();
 
 	_port = parse_port_number(argv[1]);
+	_str_port = argv[1];
 }
 
 
 uint16_t		Configuration::getPort(void) const
 {
 	return this->_port;
+}
+
+char			*Configuration::getStrPort(void) const
+{
+	return this->_str_port;
 }

--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -1,3 +1,4 @@
+#include <cstring>
 #include "catch.hpp"
 
 #define private public
@@ -58,5 +59,6 @@ TEST_CASE("Configuration::parse_arguments()")
 		conf.parse_arguments(3, argv);
 
 		REQUIRE( conf.getPort() == 6667 );
+		REQUIRE( strcmp(conf.getStrPort(), "6667") == 0 );
 	}
 }


### PR DESCRIPTION
This attribute will probably be needed for the `getaddrinfo` call.