### PR TITLE
fix: remove Server copy constructor and assignation operator

### DIFF
--- a/include/TCP/Server.hpp
+++ b/include/TCP/Server.hpp
@@ -37,10 +37,7 @@ namespace TCP {
 	{
 		public:
 			Server(char *port);
-			Server(const Server &obj);
 			~Server(void);
-		
-			Server		&operator=(const Server &rhs);
 	
 			void		listen(void);
 	

--- a/src/TCP/Server.cpp
+++ b/src/TCP/Server.cpp
@@ -16,20 +16,9 @@ namespace TCP {
 #endif
 	}
 	
-	Server::Server(const Server &obj) : _sockfd(-1), _epollfd(-1), _peers(*this), _handlers()
-	{
-		*this = obj;
-	}
-	
 	Server::~Server(void)
 	{
 		close(this->_sockfd);
-	}
-	
-	Server	&Server::operator=(const Server &rhs)
-	{
-		(void)rhs;
-		return *this;
 	}
 	
 	void		Server::_bindNewSocketToPort(char *port)


### PR DESCRIPTION
The server would bind to the same port, which would result in an error.

The user should instantiate a new server (or pass it by reference if it is automatically copied inside a function parameter).