### PR TITLE
Include source files in test files

### DIFF
--- a/include/Configuration.hpp
+++ b/include/Configuration.hpp
@@ -4,6 +4,7 @@
 # include <exception>
 # include <iostream>
 # include <string>
+# include <sstream>
 # include <stdint.h>
 
 class Configuration

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -1,5 +1,4 @@
 #include "Configuration.hpp"
-#include <sstream>
 
 Configuration::Configuration() : _parsed(false), _port(), _password()
 {

--- a/test/Configuration.test.cpp
+++ b/test/Configuration.test.cpp
@@ -1,8 +1,11 @@
 #include <cstring>
+#include <sstream>
 #include "catch.hpp"
 
 #define private public
 #include "Configuration.hpp"
+
+#include "../src/Configuration.cpp"
 
 TEST_CASE("parse_port_number")
 {

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,8 +1,10 @@
 NAME = test.out
-SRCS = main.cpp Configuration.test.cpp ../src/Configuration.cpp Message.test.cpp ../src/Message.cpp ../src/Peer.cpp ../src/Server.cpp ../src/PeerManager.cpp ../src/commands.cpp $(addprefix ../src/commands/, nick.cpp quit.cpp user.cpp)
+SRCS = main.cpp Configuration.test.cpp Message.test.cpp commands/nick.test.cpp
 OBJS = $(SRCS:.cpp=.o)
+DEPS = $(SRCS:.cpp=.d)
+INCLDIR = include
 CXX = c++
-CPPFLAGS += $(addprefix -I, . ../include) -DNDEBUG
+CPPFLAGS += -MMD $(addprefix -I, $(INCLDIR)) $(addprefix -I, . ../include) -DNDEBUG
 CXXFLAGS += -Wall -Wextra -Werror --std=c++11
 RM = rm -f
 
@@ -10,6 +12,8 @@ RM = rm -f
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $< -o $@
 
 all: $(NAME)
+
+-include $(DEPS)
 
 $(NAME): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $^ -o $@

--- a/test/Message.test.cpp
+++ b/test/Message.test.cpp
@@ -4,6 +4,11 @@
 #define private public
 #include "Message.hpp"
 
+#include "../src/Message.cpp"
+#include "../src/Peer.cpp"
+#include "../src/commands/quit.cpp"
+#include "../src/commands/user.cpp"
+
 TEST_CASE("Message::parse()")
 {
 	SECTION("Should parse full message correctly")

--- a/test/commands/nick.test.cpp
+++ b/test/commands/nick.test.cpp
@@ -9,6 +9,11 @@
 #include "Message.hpp"
 #include "Peer.hpp"
 
+#include "../src/commands.cpp"
+#include "../src/commands/nick.cpp"
+#include "../src/PeerManager.cpp"
+#include "../src/Server.cpp"
+
 
 TEST_CASE("NICK")
 {


### PR DESCRIPTION
This allow more flexibility with static functions, but it brings one drawback: it must be included only once in all files.