### PR TITLE
fix: remove an useless include in PeerManager.cpp

### DIFF
--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -1,5 +1,4 @@
 #include "PeerManager.hpp"
-#include <map>
 
 PeerManager::PeerManager(Server &server) : _server(server), _peers()
 {


### PR DESCRIPTION
@vfurmane told me i needed to make a new branch and a different commit to fix this kind of issues