### PR TITLE
Use a _base_channel class

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -5,7 +5,19 @@
 # include <string>
 # include "UserManager.hpp"
 
-class Channel
+class _base_channel
+{
+	public:
+		_base_channel(const std::string &name);
+		_base_channel(const _base_channel &obj);
+		_base_channel &operator=(const _base_channel &rhs);
+		~_base_channel(void);
+
+	protected:
+		const std::string	_name;
+};
+
+class Channel : public _base_channel
 {
 	public:
 		Channel(const std::string &name);
@@ -17,7 +29,6 @@ class Channel
 		void	unsetKey(void);
 		bool	compareKey(const std::string &key) const;
 	private:
-		const std::string	_name;
 		std::string			_key;
 		uint32_t			_flags;
 		UserManager			_users;

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,10 +1,28 @@
 #include "Channel.hpp"
 
-Channel::Channel(const std::string &name): _name(name), _key(), _flags(0), _users()
+_base_channel::_base_channel(const std::string &name): _name(name)
 {
 }
 
-Channel::Channel(const Channel &obj): _name(obj._name), _key(obj._key), _flags(obj._flags), _users(obj._users)
+_base_channel::_base_channel(const _base_channel &obj): _name(obj._name)
+{
+}
+
+_base_channel	&_base_channel::operator=(const _base_channel &rhs)
+{
+	(void)rhs;
+	return (*this);
+}
+
+_base_channel::~_base_channel(void)
+{
+}
+
+Channel::Channel(const std::string &name): _base_channel(name), _key(), _flags(0), _users()
+{
+}
+
+Channel::Channel(const Channel &obj): _base_channel(obj._name), _key(obj._key), _flags(obj._flags), _users(obj._users)
 {
 }
 


### PR DESCRIPTION
This PR adds inheritance. This is bad, **BUT**:

- This allows having a channel object without instantiating a complete channel (with user manager, ...). It will be useful for the parsing for example: we will have all the channel's information but not the non-essential things
- This does not create problems later as the used fields will not change type (like with TCPServer and IRCServer :clown_face:)