### PR TITLE
fix: remove useless Peer include 2

### DIFF
--- a/include/UserManager.hpp
+++ b/include/UserManager.hpp
@@ -21,6 +21,7 @@ class UserManager : public Manager<std::string, User>
 		void	remove(const User &user);
 };
 
+# include "Peer.hpp"
 # include "User.hpp"
 
 #endif

--- a/include/UserManager.hpp
+++ b/include/UserManager.hpp
@@ -21,7 +21,6 @@ class UserManager : public Manager<std::string, User>
 		void	remove(const User &user);
 };
 
-# include "Peer.hpp"
 # include "User.hpp"
 
 #endif


### PR DESCRIPTION
github is drunk

we try to see if we can bypass its' failed checks

everything should work fine

@vfurmane this one if for you